### PR TITLE
Enhance file server to support fallback to index.html for SPA and update configuration examples

### DIFF
--- a/Cbltfile
+++ b/Cbltfile
@@ -5,7 +5,7 @@
       lb_retries "2"
       lb_policy "round_robin"  //  "ip_hash"
 }
-    root "*" "./assets"
+    root "*" "./assets" "/index.html"
     file_server
 }
 "*:443" {

--- a/README.md
+++ b/README.md
@@ -61,24 +61,26 @@ curl -v -H "Range: bytes=0-499" http://127.0.0.1/logo.png
 
 ## "Cbltfile" configuration examples
 ### File server
+Supports SPA (Single Page Application): fall back to /index.html if not found in /path/to/folder
 ```kdl
 "*:80" {
-    root "*" "/path/to/folder"
+    root "*" "/path/to/folder" "/index.html"
     file_server
 }
 ```
+
 ### File server & Proxy
 ```kdl
 "127.0.0.1:8080" {
     reverse_proxy "/test-api/*" "http://10.8.0.3:80"
-    root "*" "/path/to/folder"
+    root "*" "/path/to/folder" "/index.html"
     file_server
 }
 ```
 ### TLS support ([docs](https://github.com/evgenyigumnov/cblt/blob/main/tls.md))
 ```kdl
 "example.com" {
-    root "*" "/path/to/folder"
+    root "*" "/path/to/folder" "/index.html"
     file_server
     tls "/path/to/your/domain.crt" "/path/to/your/domain.key"
 }
@@ -99,7 +101,7 @@ curl -v -H "Range: bytes=0-499" http://127.0.0.1/logo.png
       lb_retries "2"
       lb_policy "round_robin"  //  "ip_hash"
     }
-    root "*" "./assets"
+    root "*" "./assets" "index.html"
     file_server
 }
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ pub enum Directive {
     Root {
         pattern: String,
         path: String,
+        fallback: Option<String>, // fallback file path
     },
     FileServer,
     ReverseProxy {
@@ -68,7 +69,12 @@ pub fn build_config(doc: &KdlDocument) -> Result<HashMap<String, Vec<Directive>>
                         if args.len() >= 2 {
                             let pattern = args[0].to_string();
                             let path = args[1].to_string();
-                            directives.push(Directive::Root { pattern, path });
+                            let fallback = if args.len() >= 3 {
+                                Some(args[2].to_string())
+                            } else {
+                                None
+                            };
+                            directives.push(Directive::Root { pattern, path, fallback });
                         } else {
                             return Err(CbltError::KdlParseError {
                                 details: format!("Invalid 'root' directive for host {}", hostname),

--- a/src/directive.rs
+++ b/src/directive.rs
@@ -64,20 +64,27 @@ where
             };
 
             let mut root_path: Option<&str> = None;
+            let mut fallback_file: Option<&str> = None;
 
             for directive in &host_config.directives {
                 match directive {
-                    Directive::Root { pattern, path } => {
+                    Directive::Root { pattern, path, fallback } => {
                         #[cfg(debug_assertions)]
                         debug!("Root: {} -> {}", pattern, path);
                         if matches_pattern(pattern.as_str(), request.uri().path()) {
                             root_path = Some(path.as_str());
+                            fallback_file = fallback.as_deref();
                         }
                     }
                     Directive::FileServer => {
                         #[cfg(debug_assertions)]
-                        debug!("File server");
-                        let ret = file_server::file_directive(root_path, &request, socket).await;
+                        debug!("File server with fallback: {:?}", fallback_file);
+                        let ret = file_server::file_directive(
+                            root_path.as_deref(), 
+                            fallback_file, 
+                            &request, 
+                            socket
+                        ).await;
                         match ret {
                             Ok(_) => {
                                 log_request_response(&request, StatusCode::OK);


### PR DESCRIPTION
When configured with `root "*" "./assets" "/index.html"`, visiting `/not_exist` will fallback to `/index.html`, allowing the frontend to handle the request. This enables proper SPA (Single Page Application) routing.